### PR TITLE
feat(opencode): add questions tool usage to system prompt

### DIFF
--- a/homeModules/dev/ai/AGENTS.md
+++ b/homeModules/dev/ai/AGENTS.md
@@ -18,6 +18,25 @@ For React component architecture and hooks patterns: @docs/react-patterns.md
 For REST API design and error handling: @docs/api-standards.md
 For testing strategies and coverage requirements: @test/testing-guidelines.md
 
+## Tool Usage Guidelines
+
+### Questions Tool
+
+Use the `questions` tool whenever possible to clarify ambiguous instructions, gather user preferences, or get decisions on implementation choices before proceeding. This helps avoid rework and ensures alignment with user expectations.
+
+Use it when:
+
+- Requirements are unclear or could be interpreted multiple ways
+- Multiple valid implementation approaches exist
+- You need user preferences on style, behavior, or scope
+- The user asks for something that requires trade-off decisions
+
+Example scenarios:
+
+- "Should I add this as a new module or extend an existing one?"
+- "Do you prefer approach A or B for handling this error?"
+- "What should the default behavior be for this feature?"
+
 ## General Guidelines
 
 Read the following file immediately as it's relevant to all workflows: @rules/general-guidelines.md.


### PR DESCRIPTION
## Summary

Adds guidance to the OpenCode system prompt to encourage proactive use of the `questions` tool. This helps clarify ambiguous instructions, gather user preferences, and make implementation decisions before proceeding, reducing rework and improving alignment.

## Changes

- Added a new **"Tool Usage Guidelines"** section to `homeModules/dev/ai/AGENTS.md`
- Documented when and why to use the `questions` tool
- Included concrete example scenarios to guide usage

## Testing

- Verified the AGENTS.md file renders correctly
- Confirmed no breaking changes to existing prompt structure